### PR TITLE
Ignore hidden file in the src folder

### DIFF
--- a/bin/jj2c
+++ b/bin/jj2c
@@ -7,6 +7,8 @@ import json
 import os
 import sys
 
+import yaml
+
 from jj2c import eprint
 import jj2c
 
@@ -16,11 +18,7 @@ AP.add_argument(
     '-V', '--variables', default=[],
     nargs='+', help='Content or files pointing to variables. Supported formats are: json, yaml and toml.')
 AP.add_argument('-o', '--output', default='-', help='where to save the file')
-AP.add_argument(
-    '-i', '--inspect',
-    action='store_true',
-    default=False,
-    help='Inspect parameters')
+AP.add_argument('-i', '--inspect', action='store_true', default=False, help='Inspect parameters')
 
 
 def is_tpl(fpath):

--- a/bin/jj2c
+++ b/bin/jj2c
@@ -18,6 +18,8 @@ AP.add_argument(
 AP.add_argument('-o', '--output', default='-', help='where to save the file')
 AP.add_argument(
     '-i', '--inspect',
+    action='store_true',
+    default=False,
     help='Inspect parameters')
 
 
@@ -48,10 +50,12 @@ def dump_file(fpath, content):
 def main(args):
   variables = {}
   for file_or_content in args.variables:
-    eprint('Parsing variables from: {}'.format(file_or_content))
+    if args.inspect:
+      eprint('Parsing variables from: {}'.format(file_or_content))
     x_variables = load_variables(file_or_content)
-    eprint(yaml.dump(x_variables))
-    eprint('-----\n')
+    if args.inspect:
+      eprint(yaml.dump(x_variables))
+      eprint('-----\n')
     variables.update(x_variables)
 
   template_path = args.template

--- a/jj2c/__init__.py
+++ b/jj2c/__init__.py
@@ -94,6 +94,7 @@ class BatchCompiler(object):
     os.makedirs(self.output_dir, exist_ok=True)
 
     for root, dirs, files in os.walk(self.template_dir):
+      files = [x for x in files if not x.startswith('.')]          
       for fname in files:
         dir_name = root[len(self.template_dir) + 1:]
         dir_out = os.path.join(self.output_dir, dir_name)


### PR DESCRIPTION
jj2c failed when I open the template files in vim, because vim creates the dot file (.abc.swp), so I added the filter to ignore . files. 
Support the -i flag to reduce the output, unless you give -i to force print more information